### PR TITLE
Adding dependencies guide not included in the sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -1,7 +1,7 @@
 module.exports = {
   docs: {
     'Getting Started': ['installation', 'editor-configuration'],
-    Basics: ['building', 'packaging', 'adding-assets'],
+    Basics: ['building', 'packaging', 'adding-assets', 'adding-dependencies'],
     Testing: ['component-tests', 'e2e-tests', 'ci'],
     Advanced: ['internals', 'tool-tips', 'dev-tools', 'faq'],
     Guides: ['upgrade-guide'],


### PR DESCRIPTION
Hello, during development I have noticed lack dependency guide on the site. After searching through issues I have found links to the guide but it wasn't included in the sidebar. This PR should just include that doc page in the sidebar of docs.