### PR TITLE
Update adding-assets.md

### DIFF
--- a/docs/adding-assets.md
+++ b/docs/adding-assets.md
@@ -38,8 +38,6 @@ This is so that [electron-builder's configuration](https://www.electron.build/co
 
 (Note that these locations are relative to the `app/` directory)
 
-For example, you can include Python within your electron app and call it at run-time.
-
 ```jsonc
 "build": {
     ...
@@ -49,6 +47,8 @@ For example, you can include Python within your electron app and call it at run-
     ],
 }
 ```
+
+For example, you can include Python within your electron app and call it at run-time to print `Hello World from Python`.
 
 ```js
 const pythonBinary = path.join(__dirname, 'assets', 'python');

--- a/docs/adding-assets.md
+++ b/docs/adding-assets.md
@@ -6,20 +6,16 @@ sidebar_label: Adding Assets
 
 A common part of applications is importing assets, such as images, fonts, and files.
 
-Assets can be used at build-time with Webpack (e.g. ) or dynamically using.
-
 ## Build-time Assets
 
-Build-time assets are managed by Webpack. Importing them is similar to importing JS modules.
+In the context of ERB, build-time assets are those that are managed by Webpack. They are imported like JS modules and transformed to encoded strings by Webpack.
 
-In these cases, Webpack handles the importing of assets. Out of the box, ERB supports the following assets:
+Out of the box, ERB supports the following assets:
 
 | Asset    |  Supported Extensions    |
 |----------|:-----------------------: |
 | Images   |  `.jpg`, `.png`, `.jpg`  |
 | Fonts    |  `.svg`, `.ttf`, `.eot`  | 
-
-Images are imported as encoded strings.
 
 ```js
 import catImage from './cat.jpg';
@@ -33,8 +29,7 @@ function CatComponent() {
 
 ## Run-time Assets
 
-If you do not want assets managed by Webpack, you will need to include their locations in the `build.files` property within `package.json`. 
-This is so that [electron-builder's configuration](https://www.electron.build/configuration/contents#files) knows which files to include when packaging.
+In the context of ERB, run-time assets are separate files that are included in the packaged application and used through file paths. You will need to include their locations in `package.json['build']['files']`. This is so that [electron-builder's configuration](https://www.electron.build/configuration/contents#files) knows to include them when packaging.
 
 (Note that these locations are relative to the `app/` directory)
 
@@ -58,7 +53,7 @@ exec(`echo '${pythonScript}' | ${pythonBinary}`, (error, stdout) => {
 });
 ```
 
-You can use `asar` (the format that `electron-builder` packages into) to see the contents of the packaged build.
+As a useful tip, you can use `asar` (the format that `electron-builder` packages into) to see the contents of the packaged build. You will see that it contains content included within `package.json['build']['files']`.
 
 ```bash
 asar list release/mac/ElectronReact.app/Contents/Resources/app.asar

--- a/docs/adding-assets.md
+++ b/docs/adding-assets.md
@@ -55,6 +55,7 @@ exec(`echo '${pythonScript}' | ${pythonBinary}`, (error, stdout) => {
 
 [Here is a runnable example of this](https://github.com/electron-react-boilerplate/examples/commit/d1eddcd0e30ec22edd3fd3900ee3c12e1da4cdba)
 
+A useful tip is using `asar` (the format that `electron-builder` packages into) to see the contents of the packaged build. You will see that it contains content included within `package.json['build']['files']`.
 
 ```bash
 asar list release/mac/ElectronReact.app/Contents/Resources/app.asar

--- a/docs/adding-assets.md
+++ b/docs/adding-assets.md
@@ -33,7 +33,10 @@ function CatComponent() {
 
 ## Run-time Assets
 
-If you do not want assets managed by Webpack, then you will need to include their locations in the `build` property within `package.json`. (Note that these locations are relative to the `app/` directory)
+If you do not want assets managed by Webpack, you will need to include their locations in the `build.files` property within `package.json`. 
+This is so that [electron-builder's configuration](https://www.electron.build/configuration/contents#files) knows which files to include when packaging.
+
+(Note that these locations are relative to the `app/` directory)
 
 For example, you can include Python within your electron app and call it at run-time.
 

--- a/docs/adding-assets.md
+++ b/docs/adding-assets.md
@@ -44,6 +44,7 @@ For example, you can include Python within your electron app and call it at run-
       "assets/"
       ...
     ],
+}
 ```
 
 ```js

--- a/docs/adding-assets.md
+++ b/docs/adding-assets.md
@@ -53,7 +53,8 @@ exec(`echo '${pythonScript}' | ${pythonBinary}`, (error, stdout) => {
 });
 ```
 
-As a useful tip, you can use `asar` (the format that `electron-builder` packages into) to see the contents of the packaged build. You will see that it contains content included within `package.json['build']['files']`.
+[Here is a runnable example of this](https://github.com/electron-react-boilerplate/examples/commit/d1eddcd0e30ec22edd3fd3900ee3c12e1da4cdba)
+
 
 ```bash
 asar list release/mac/ElectronReact.app/Contents/Resources/app.asar

--- a/docs/adding-assets.md
+++ b/docs/adding-assets.md
@@ -37,7 +37,7 @@ If you do not want assets managed by Webpack, then you will need to include thei
 
 For example, you can include Python within your electron app and call it at run-time.
 
-```
+```jsonc
 "build": {
     ...
     "files": [
@@ -57,6 +57,6 @@ exec(`echo '${pythonScript}' | ${pythonBinary}`, (error, stdout) => {
 
 You can use `asar` (the format that `electron-builder` packages into) to see the contents of the packaged build.
 
-```
+```bash
 asar list release/mac/ElectronReact.app/Contents/Resources/app.asar
 ```

--- a/docs/adding-assets.md
+++ b/docs/adding-assets.md
@@ -4,18 +4,22 @@ title: Adding Assets
 sidebar_label: Adding Assets
 ---
 
-A common part of applications is importing assets, such as images, fonts, and files. Webpack handles the importing of assets.
+A common part of applications is importing assets, such as images, fonts, and files.
 
-## Importing Assets
+Assets can be used at build-time with Webpack (e.g. ) or dynamically using.
 
-Out of the box, ERB supports the following assets:
+## Build-time Assets
+
+Build-time assets are managed by Webpack. Importing them is similar to importing JS modules.
+
+In these cases, Webpack handles the importing of assets. Out of the box, ERB supports the following assets:
 
 | Asset    |  Supported Extensions    |
 |----------|:-----------------------: |
 | Images   |  `.jpg`, `.png`, `.jpg`  |
 | Fonts    |  `.svg`, `.ttf`, `.eot`  | 
 
-Importing assets is similar to importing JS modules. Images are imported as encoded strings.
+Images are imported as encoded strings.
 
 ```js
 import catImage from './cat.jpg';
@@ -25,4 +29,33 @@ function CatComponent() {
     <img src={catImage} />
   );
 }
+```
+
+## Run-time Assets
+
+If you do not want assets managed by Webpack, then you will need to include their locations in the `build` property within `package.json`. (Note that these locations are relative to the `app/` directory)
+
+For example, you can include Python within your electron app and call it at run-time.
+
+```
+"build": {
+    ...
+    "files": [
+      "assets/"
+      ...
+    ],
+```
+
+```js
+const pythonBinary = path.join(__dirname, 'assets', 'python');
+const pythonScript = 'print("Hello World from Python")';
+exec(`echo '${pythonScript}' | ${pythonBinary}`, (error, stdout) => {
+  console.log(`stdout: ${stdout}`);
+});
+```
+
+You can use `asar` (the format that `electron-builder` packages into) to see the contents of the packaged build.
+
+```
+asar list release/mac/ElectronReact.app/Contents/Resources/app.asar
 ```


### PR DESCRIPTION
Update docs on adding assets to cover non-Webpack/runtime assets. Related to https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/2526

Closes #132 